### PR TITLE
Remove unused parse token types

### DIFF
--- a/src/utils/types/parseToken.types.ts
+++ b/src/utils/types/parseToken.types.ts
@@ -1,6 +1,0 @@
-type parsedJwtToken = {
-  exp?: number;
-  id: string;
-};
-
-export type { parsedJwtToken };


### PR DESCRIPTION
## Summary
- clean up unused parsedJwtToken definition

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'video.js')*

------
https://chatgpt.com/codex/tasks/task_e_68669362de1c8324bf966ba6e42e0713