### PR TITLE
Add Storybook with ExampleButton component

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,0 +1,8 @@
+module.exports = {
+  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
+  framework: {
+    name: '@storybook/vue3-vite',
+    options: {},
+  },
+};

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,0 +1,3 @@
+export const parameters = {
+  actions: { argTypesRegex: '^on[A-Z].*' },
+};

--- a/README.md
+++ b/README.md
@@ -118,3 +118,15 @@ npm run build
 ```bash
 npm run lint
 ```
+
+### 8. Storybook
+
+Run the component library in Storybook:
+
+```bash
+npm run storybook
+```
+
+Add new stories alongside components using the `*.stories.tsx` pattern. See
+`src/packages/ui/atoms/ExampleButton/ExampleButton.stories.tsx` for a minimal
+example.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build:customized-tone": "cd ./packages/customized-tone && npm run build",
     "build:jam-galaxy": "node --max-old-space-size=12288 node_modules/@vue/cli-service/bin/vue-cli-service.js build",
     "build": "npm run build:customized-tone && npm run build:jam-galaxy",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "engines": {
     "node": ">=20"
@@ -98,7 +100,10 @@
     "stream-http": "^3.2.0",
     "typescript": "~4.9.4",
     "url": "^0.11.3",
-    "webpack-cli": "^6.0.1"
+    "webpack-cli": "^6.0.1",
+    "@storybook/vue3": "^7.6.0",
+    "@storybook/addon-essentials": "^7.6.0",
+    "@storybook/addon-links": "^7.6.0"
   },
   "eslintConfig": {
     "root": true,

--- a/src/packages/ui/atoms/ExampleButton/ExampleButton.stories.tsx
+++ b/src/packages/ui/atoms/ExampleButton/ExampleButton.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import ExampleButton from './ExampleButton.vue';
+
+const meta: Meta<typeof ExampleButton> = {
+  title: 'Atoms/ExampleButton',
+  component: ExampleButton,
+};
+
+export default meta;
+
+export const Basic: StoryObj<typeof ExampleButton> = {
+  render: () => ({
+    components: { ExampleButton },
+    template: '<ExampleButton>Click me</ExampleButton>',
+  }),
+};

--- a/src/packages/ui/atoms/ExampleButton/ExampleButton.vue
+++ b/src/packages/ui/atoms/ExampleButton/ExampleButton.vue
@@ -1,0 +1,21 @@
+<template>
+  <button class="example-button" @click="$emit('click')">
+    <slot>Button</slot>
+  </button>
+</template>
+
+<script>
+export default {
+  name: "ExampleButton",
+};
+</script>
+
+<style scoped>
+.example-button {
+  padding: 0.5rem 1rem;
+  border: none;
+  background-color: #42b983;
+  color: white;
+  cursor: pointer;
+}
+</style>


### PR DESCRIPTION
## Summary
- setup Storybook configuration
- add `ExampleButton` component and stories
- add npm scripts for Storybook
- document Storybook usage in README

## Testing
- `npm run lint` *(fails: `vue-cli-service: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6872906e476c8324b86168d7ded7e3da